### PR TITLE
Os specific

### DIFF
--- a/apt-vim
+++ b/apt-vim
@@ -44,17 +44,6 @@ class Dependency(PkgItem):
         # Convert python variable names to json variable names
         return {k.replace('_', '-'): v for k,v in self.__dict__.items()}
 
-    #def get_recipe(self):
-        #recipe = []
-        #if HOST_OS in self.recipe:
-            #recipe = self.recipe[HOST_OS]
-        #elif 'all' in self.recipe:
-            #recipe = self.recipe['all']
-        #if self.recipe and not recipe:
-            #if not report_fail('No recipe for your OS'):
-                #sys.exit(1)
-        #return recipe
-
     @staticmethod
     def dict_to_dep(d):
         return Dependency(d[NAME], d[RECIPE])
@@ -73,17 +62,6 @@ class VimPackage(PkgItem):
         deps = [ dep.to_dict() for dep in self.depends_on ]
         d[DPND] = deps
         return d
-
-    #def get_recipe(self):
-        #recipe = []
-        #if HOST_OS in self.recipe:
-            #recipe = self.recipe[HOST_OS]
-        #elif 'all' in self.recipe:
-            #recipe = self.recipe['all']
-        #if self.recipe and not recipe:
-            #if not report_fail('No recipe for your OS'):
-                #sys.exit(1)
-        #return recipe
 
     @staticmethod
     def dict_to_vimpkg(d):
@@ -261,6 +239,7 @@ def get_depend(pkg_name='this plugin'):
 def __get_depend(name):
     dep = Dependency(name)
     recipe = get_recipe()
+    # Only save the recipe if there is a recipe to save...
     if recipe:
         dep.recipe[HOST_OS] = recipe
     return dep

--- a/apt-vim
+++ b/apt-vim
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import json, sys, os, re, shutil, shlex, getopt
+import json, sys, os, re, shutil, shlex, getopt, platform
 from distutils.util import strtobool
 from subprocess import call, check_output, CalledProcessError
 
@@ -15,24 +15,38 @@ PKG_URL = 'pkg-url'
 PKGS = 'packages'
 RECIPE = 'recipe'
 VIM_CONFIG = None
+OS = 'os'
+HOST_OS = platform.system().lower()
 VIM_CONFIG_PATH = os.path.join(SCRIPT_ROOT_DIR, 'vim_config.json')
 
 ####### CMD LINE FLAGS #######
 ASSUME_YES = False
 
+class Recipe:
+    #def __init__(self, recipe=[], os=''):
+        #self.recipe = recipe
+        #self.os = os
+
+    #def to_dict(self):
+        ## Convert python variable names to json variable names
+        #return self.__dict__
+
+    @staticmethod
+    def dict_to_recipe(d):
+        return Recipe(d[RECIPE], d[OS])
+
+
 class Dependency:
-    def __init__(self, name='dep', recipe=[]):
+    def __init__(self, name='dep', recipe={}):
         self.name = name
         self.recipe = recipe
 
-    def to_json(self):
-        res = json.dumps(self, default=lambda o: o.__dict__)
-        # Convert python variable names to json variable names
-        return res.replace('_', '-')
-
     def to_dict(self):
         # Convert python variable names to json variable names
-        return {k.replace('_', '-'): v for k,v in self.__dict__.items()}
+        d = {k.replace('_', '-'): v for k,v in self.__dict__.items()}
+        #recipes = [ r.to_dict() for r in self.recipe ]
+        #d[RECIPE] = recipes
+        return d
 
     @staticmethod
     def dict_to_dep(d):
@@ -40,22 +54,19 @@ class Dependency:
 
 
 class VimPackage:
-    def __init__(self, pkg_url='', name='', depends_on=[], recipe=[]):
+    def __init__(self, pkg_url='', name='', depends_on=[], recipe={}):
         self.pkg_url = pkg_url
         self.name = name
         self.depends_on = depends_on
         self.recipe = recipe
 
-    def to_json(self):
-        res = json.dumps(self, default=lambda o: o.__dict__)
-        # Convert python variable names to json variable names
-        return res.replace('_', '-')
-
     def to_dict(self):
         # Convert python variable names to json variable names
         d = {k.replace('_', '-'): v for k,v in self.__dict__.items()}
         deps = [ dep.to_dict() for dep in self.depends_on ]
+        #recipes = [ r.to_dict() for r in self.recipe ]
         d[DPND] = deps
+        #d[RECIPE] = recipes
         return d
 
     @staticmethod
@@ -93,7 +104,10 @@ def install_pkg(vimpkg):
     # Install dependencies of package
     install_dependencies(vimpkg.name, vimpkg.depends_on)
     # Clone the plugin and run any post-install commands
-    __install_pkg(vimpkg.name, vimpkg.pkg_url, install_target, vimpkg.recipe)
+    recipe_name = 'all'
+    if HOST_OS in vimpkg.recipe:
+        recipe_name = HOST_OS
+    __install_pkg(vimpkg.name, vimpkg.pkg_url, install_target, vimpkg.recipe[recipe_name])
     # Change back to the DIR containing this script
     os.chdir(SCRIPT_ROOT_DIR)
 
@@ -126,7 +140,8 @@ def add_pkg(pkg_name, git_url):
 
     msg = 'Any commands to run after cloning `' + pkg_name + '`?'
     post_install_recipe = get_recipe(msg)
-    vimpkg.recipe = post_install_recipe
+    if post_install_recipe:
+        vimpkg.recipe[HOST_OS] = post_install_recipe
     return vimpkg
 
 def clone_pkg(git_url, pkg_name=None):
@@ -154,7 +169,10 @@ def install_dependencies(pkg_name, dependencies=[]):
         os.chdir(pkg_name)
 
     for dep in dependencies:
-        commands = dep.recipe
+        recipe_name = 'all'
+        if HOST_OS in dep.recipe:
+            recipe_name = HOST_OS
+        commands = dep.recipe[recipe_name]
         if not exe_shell_commands(commands):
             report_fail('Failed to intall ' + pkg_name)
 
@@ -231,7 +249,9 @@ def get_depend(pkg_name='this plugin'):
 
 def __get_depend(name):
     dep = Dependency(name)
-    dep.recipe = get_recipe()
+    recipe = get_recipe()
+    if recipe:
+        dep.recipe[HOST_OS] = recipe
     return dep
 
 def get_recipe(msg=None):
@@ -457,6 +477,7 @@ def main():
         print 'Cannot proceed. Missing the following dependencies that could' \
                 + ' not be automatically insatlled:\n' \
                 + str(missing_dependencies)
+    load_vim_config()
     process_cmd_args()
     print 'Completed successfully!'
 

--- a/apt-vim
+++ b/apt-vim
@@ -22,38 +22,45 @@ VIM_CONFIG_PATH = os.path.join(SCRIPT_ROOT_DIR, 'vim_config.json')
 ####### CMD LINE FLAGS #######
 ASSUME_YES = False
 
-class Recipe:
-    #def __init__(self, recipe=[], os=''):
-        #self.recipe = recipe
-        #self.os = os
 
-    #def to_dict(self):
-        ## Convert python variable names to json variable names
-        #return self.__dict__
+class PkgItem(object):
+    def get_recipe(self):
+        recipe = []
+        if HOST_OS in self.recipe:
+            recipe = self.recipe[HOST_OS]
+        elif 'all' in self.recipe:
+            recipe = self.recipe['all']
+        if self.recipe and not recipe:
+            if not report_fail('No recipe for your OS'):
+                sys.exit(1)
+        return recipe
 
-    @staticmethod
-    def dict_to_recipe(d):
-        return Recipe(d[RECIPE], d[OS])
-
-
-class Dependency:
+class Dependency(PkgItem):
     def __init__(self, name='dep', recipe={}):
         self.name = name
         self.recipe = recipe
 
     def to_dict(self):
         # Convert python variable names to json variable names
-        d = {k.replace('_', '-'): v for k,v in self.__dict__.items()}
-        #recipes = [ r.to_dict() for r in self.recipe ]
-        #d[RECIPE] = recipes
-        return d
+        return {k.replace('_', '-'): v for k,v in self.__dict__.items()}
+
+    #def get_recipe(self):
+        #recipe = []
+        #if HOST_OS in self.recipe:
+            #recipe = self.recipe[HOST_OS]
+        #elif 'all' in self.recipe:
+            #recipe = self.recipe['all']
+        #if self.recipe and not recipe:
+            #if not report_fail('No recipe for your OS'):
+                #sys.exit(1)
+        #return recipe
 
     @staticmethod
     def dict_to_dep(d):
         return Dependency(d[NAME], d[RECIPE])
 
 
-class VimPackage:
+class VimPackage(PkgItem):
     def __init__(self, pkg_url='', name='', depends_on=[], recipe={}):
         self.pkg_url = pkg_url
         self.name = name
@@ -64,10 +71,19 @@ class VimPackage:
         # Convert python variable names to json variable names
         d = {k.replace('_', '-'): v for k,v in self.__dict__.items()}
         deps = [ dep.to_dict() for dep in self.depends_on ]
-        #recipes = [ r.to_dict() for r in self.recipe ]
         d[DPND] = deps
-        #d[RECIPE] = recipes
         return d
+
+    #def get_recipe(self):
+        #recipe = []
+        #if HOST_OS in self.recipe:
+            #recipe = self.recipe[HOST_OS]
+        #elif 'all' in self.recipe:
+            #recipe = self.recipe['all']
+        #if self.recipe and not recipe:
+            #if not report_fail('No recipe for your OS'):
+                #sys.exit(1)
+        #return recipe
 
     @staticmethod
     def dict_to_vimpkg(d):
@@ -104,11 +120,7 @@ def install_pkg(vimpkg):
     # Install dependencies of package
     install_dependencies(vimpkg.name, vimpkg.depends_on)
     # Clone the plugin and run any post-install commands
-    recipe = []
-    if HOST_OS in vimpkg.recipe:
-        recipe = vimpkg.recipe[HOST_OS]
-    elif 'all' in vimpkg.recipe:
-        recipe = vimpkg.recipe['all']
+    recipe = vimpkg.get_recipe()
     __install_pkg(vimpkg.name, vimpkg.pkg_url, install_target, recipe)
     # Change back to the DIR containing this script
     os.chdir(SCRIPT_ROOT_DIR)
@@ -171,10 +183,7 @@ def install_dependencies(pkg_name, dependencies=[]):
         os.chdir(pkg_name)
 
     for dep in dependencies:
-        recipe_name = 'all'
-        if HOST_OS in dep.recipe:
-            recipe_name = HOST_OS
-        commands = dep.recipe[recipe_name]
+        commands = dep.get_recipe()
         if not exe_shell_commands(commands):
             report_fail('Failed to intall ' + pkg_name)
 

--- a/apt-vim
+++ b/apt-vim
@@ -361,9 +361,11 @@ def init():
     missing_deps = []
     deps = VIM_CONFIG[GBL][DPND]
     for dep in deps:
-        if not check_requirements([dep[NAME]]):
-            if not exe_shell_commands(dep[RECIPE]):
-                missing_deps.append(dep[NAME])
+        dep = Dependency.dict_to_dep(dep)
+        if not check_requirements([dep.name]):
+            if not dep.get_recipe() or  \
+                    not exe_shell_commands(dep.get_recipe()):
+                missing_deps.append(dep.name)
     return missing_deps
 
 def get_urls_from_list(check_list):

--- a/apt-vim
+++ b/apt-vim
@@ -469,6 +469,7 @@ def main():
         print 'Cannot proceed. Missing the following dependencies that could' \
                 + ' not be automatically insatlled:\n' \
                 + str(missing_dependencies)
+        sys.exit(1)
     load_vim_config()
     process_cmd_args()
     print 'Completed successfully!'

--- a/apt-vim
+++ b/apt-vim
@@ -104,10 +104,12 @@ def install_pkg(vimpkg):
     # Install dependencies of package
     install_dependencies(vimpkg.name, vimpkg.depends_on)
     # Clone the plugin and run any post-install commands
-    recipe_name = 'all'
+    recipe = []
     if HOST_OS in vimpkg.recipe:
-        recipe_name = HOST_OS
-    __install_pkg(vimpkg.name, vimpkg.pkg_url, install_target, vimpkg.recipe[recipe_name])
+        recipe = vimpkg.recipe[HOST_OS]
+    elif 'all' in vimpkg.recipe:
+        recipe = vimpkg.recipe['all']
+    __install_pkg(vimpkg.name, vimpkg.pkg_url, install_target, recipe)
     # Change back to the DIR containing this script
     os.chdir(SCRIPT_ROOT_DIR)
 

--- a/vim_config.json
+++ b/vim_config.json
@@ -25,6 +25,17 @@
         	}	                
         },
         {
+        	"depends-on": [],
+        	"name": "TEST_PACKAGE",
+        	"pkg-url": "https://github.com/brookhong/cscope.vim.git",
+        	"recipe": {
+        		"darwin": [
+        			"ls",
+        			"pwd"
+        		]
+        	}
+    	},
+        {
             "depends-on": [
                 {
                     "name": "ctags",

--- a/vim_config.json
+++ b/vim_config.json
@@ -18,34 +18,34 @@
             "name": "pathogen",
             "pkg-url": "https://github.com/tpope/vim-pathogen.git",
             "recipe": {
-            	"all": [
-	            	"mkdir -p ~/.vim/autoload ~/.vim/bundle",
-	                "curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim"
-            	]
-        	}
+                "all": [
+                    "mkdir -p ~/.vim/autoload ~/.vim/bundle",
+                    "curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim"
+                ]
+            }
         },
         {
             "depends-on": [
                 {
                     "name": "ctags",
                     "recipe": {
-		            	"darwin": [
-		            		"curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
-	                        "tar xzf ctags-5.8.tar.gz",
-	                        "cd ctags-5.8",
-	                        "sudo ./configure",
-	                        "sudo make",
-	                        "sudo make install"
-		            	],
-		            	"linux": [
-		            		"curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
-	                        "tar xzf ctags-5.8.tar.gz",
-	                        "cd ctags-5.8",
-	                        "sudo ./configure",
-	                        "sudo make",
-	                        "sudo make install"
-		            	]
-		            }
+                        "darwin": [
+                            "curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
+                            "tar xzf ctags-5.8.tar.gz",
+                            "cd ctags-5.8",
+                            "sudo ./configure",
+                            "sudo make",
+                            "sudo make install"
+                        ],
+                        "linux": [
+                            "curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
+                            "tar xzf ctags-5.8.tar.gz",
+                            "cd ctags-5.8",
+                            "sudo ./configure",
+                            "sudo make",
+                            "sudo make install"
+                        ]
+                    }
                 }
             ],
             "name": "tagbar",

--- a/vim_config.json
+++ b/vim_config.json
@@ -22,19 +22,8 @@
 	            	"mkdir -p ~/.vim/autoload ~/.vim/bundle",
 	                "curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim"
             	]
-        	}	                
-        },
-        {
-        	"depends-on": [],
-        	"name": "TEST_PACKAGE",
-        	"pkg-url": "https://github.com/brookhong/cscope.vim.git",
-        	"recipe": {
-        		"darwin": [
-        			"ls",
-        			"pwd"
-        		]
         	}
-    	},
+        },
         {
             "depends-on": [
                 {
@@ -61,84 +50,6 @@
             ],
             "name": "tagbar",
             "pkg-url": "https://github.com/majutsushi/tagbar.git",
-            "recipe": {}
-        },
-        {
-            "depends-on": [
-                {
-                    "name": "cscope",
-                    "recipe": {
-		            	"darwin": [
-		            		"curl -LSso cscope-15.8b.tar.gz http://sourceforge.net/projects/cscope/files/latest/download?source=files",
-	                        "tar xzf cscope-15.8b.tar.gz",
-	                        "cd cscope-15.8b",
-	                        "sudo ./configure",
-	                        "sudo make",
-	                        "sudo make install"
-		            	],
-		            	"linux": [
-		            		"curl -LSso cscope-15.8b.tar.gz http://sourceforge.net/projects/cscope/files/latest/download?source=files",
-	                        "tar xzf cscope-15.8b.tar.gz",
-	                        "cd cscope-15.8b",
-	                        "sudo ./configure",
-	                        "sudo make",
-	                        "sudo make install"
-		            	]
-		            }
-                }
-            ],
-            "name": "cscope.vim",
-            "pkg-url": "https://github.com/brookhong/cscope.vim.git",
-            "recipe": {}
-        },
-        {
-            "depends-on": [],
-            "name": "YouCompleteMe",
-            "pkg-url": "https://github.com/Valloric/YouCompleteMe.git",
-            "recipe": {
-            	"all": [
-            		"git submodule update --init --recursive",
-                	"./install.sh --clang-completer"
-            	]
-            }
-        },
-        {
-            "depends-on": [],
-            "name": "tagbar-phpctags.vim",
-            "pkg-url": "https://github.com/vim-php/tagbar-phpctags.vim.git",
-            "recipe": {
-            	"all": [
-            		"make"
-            	]
-            }
-        },
-        {
-            "depends-on": [],
-            "name": "vimproc.vim",
-            "pkg-url": "https://github.com/Shougo/vimproc.vim.git",
-            "recipe": {
-            	"all": [
-            		"make"
-            	]
-            }
-        },
-        {
-            "depends-on": [
-                {
-                    "name": "node",
-                    "recipe": {
-                        "darwin": [
-                            "ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"",
-                            "brew install node"
-                        ],
-                        "linux": [
-                        	"sudo apt-get install -y node npm"
-                        ]
-                    }
-                }
-            ],
-            "name": "tern_for_vim",
-            "pkg-url": "https://github.com/marijnh/tern_for_vim.git",
             "recipe": {}
         }
     ]

--- a/vim_config.json
+++ b/vim_config.json
@@ -3,11 +3,11 @@
         "depends-on": [
             {
                 "name": "git",
-                "recipe": []
+                "recipe": {}
             },
             {
                 "name": "python",
-                "recipe": []
+                "recipe": {}
             }
         ],
         "install-target": "~/.vimpkg/bundle"
@@ -17,28 +17,118 @@
             "depends-on": [],
             "name": "pathogen",
             "pkg-url": "https://github.com/tpope/vim-pathogen.git",
-            "recipe": [
-                "mkdir -p ~/.vim/autoload ~/.vim/bundle",
-                "curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim"
-            ]
+            "recipe": {
+            	"all": [
+	            	"mkdir -p ~/.vim/autoload ~/.vim/bundle",
+	                "curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim"
+            	]
+        	}	                
         },
         {
             "depends-on": [
                 {
                     "name": "ctags",
-                    "recipe": [
-                        "curl -LSso ctags-5.8.tar.gz 'http://iweb.dl.sourceforge.net/project/ctags/ctags/5.8/ctags-5.8.tar.gz'",
-                        "tar xzf ctags-5.8.tar.gz",
-                        "cd ctags-5.8",
-                        "sudo ./configure",
-                        "sudo make",
-                        "sudo make install"
-                    ]
+                    "recipe": {
+		            	"darwin": [
+		            		"curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
+	                        "tar xzf ctags-5.8.tar.gz",
+	                        "cd ctags-5.8",
+	                        "sudo ./configure",
+	                        "sudo make",
+	                        "sudo make install"
+		            	],
+		            	"linux": [
+		            		"curl -LSso ctags-5.8.tar.gz 'http://sourceforge.net/projects/ctags/files/ctags/5.8/ctags-5.8.tar.gz/download?use_mirror=iweb'",
+	                        "tar xzf ctags-5.8.tar.gz",
+	                        "cd ctags-5.8",
+	                        "sudo ./configure",
+	                        "sudo make",
+	                        "sudo make install"
+		            	]
+		            }
                 }
             ],
             "name": "tagbar",
             "pkg-url": "https://github.com/majutsushi/tagbar.git",
-            "recipe": []
+            "recipe": {}
+        },
+        {
+            "depends-on": [
+                {
+                    "name": "cscope",
+                    "recipe": {
+		            	"darwin": [
+		            		"curl -LSso cscope-15.8b.tar.gz http://sourceforge.net/projects/cscope/files/latest/download?source=files",
+	                        "tar xzf cscope-15.8b.tar.gz",
+	                        "cd cscope-15.8b",
+	                        "sudo ./configure",
+	                        "sudo make",
+	                        "sudo make install"
+		            	],
+		            	"linux": [
+		            		"curl -LSso cscope-15.8b.tar.gz http://sourceforge.net/projects/cscope/files/latest/download?source=files",
+	                        "tar xzf cscope-15.8b.tar.gz",
+	                        "cd cscope-15.8b",
+	                        "sudo ./configure",
+	                        "sudo make",
+	                        "sudo make install"
+		            	]
+		            }
+                }
+            ],
+            "name": "cscope.vim",
+            "pkg-url": "https://github.com/brookhong/cscope.vim.git",
+            "recipe": {}
+        },
+        {
+            "depends-on": [],
+            "name": "YouCompleteMe",
+            "pkg-url": "https://github.com/Valloric/YouCompleteMe.git",
+            "recipe": {
+            	"all": [
+            		"git submodule update --init --recursive",
+                	"./install.sh --clang-completer"
+            	]
+            }
+        },
+        {
+            "depends-on": [],
+            "name": "tagbar-phpctags.vim",
+            "pkg-url": "https://github.com/vim-php/tagbar-phpctags.vim.git",
+            "recipe": {
+            	"all": [
+            		"make"
+            	]
+            }
+        },
+        {
+            "depends-on": [],
+            "name": "vimproc.vim",
+            "pkg-url": "https://github.com/Shougo/vimproc.vim.git",
+            "recipe": {
+            	"all": [
+            		"make"
+            	]
+            }
+        },
+        {
+            "depends-on": [
+                {
+                    "name": "node",
+                    "recipe": {
+                        "darwin": [
+                            "ruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"",
+                            "brew install node"
+                        ],
+                        "linux": [
+                        	"sudo apt-get install -y node npm"
+                        ]
+                    }
+                }
+            ],
+            "name": "tern_for_vim",
+            "pkg-url": "https://github.com/marijnh/tern_for_vim.git",
+            "recipe": {}
         }
     ]
 }


### PR DESCRIPTION
Now, OS specific installation recipes can be maintained. There is no automated process for creating recipes for and OS that you are not currently running. However, recipes that you create are automatically assigned to the OS that you are running.

To create recipe for another OS, you can manually edit the file `~/.vimpkg/vim_config.json`.  If you wish to use the same recipe for ALL OS's, you can change the identifier of the corresponding recipe in `~/.vimpkg/vim_config.json` to `all`
