### PR TITLE
make it easer to copy-paste the automatic install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _Don't worry:_
 
 ##Option 1 - Automatic
 
-    curl -sL https://raw.githubusercontent.com/egalpin/apt-vim/master/install.sh|sh
+    curl -sL https://raw.githubusercontent.com/egalpin/apt-vim/master/install.sh | sh
 _Note: you may need to close and reopen your terminal_
 
 ##Option 2 - Manual


### PR DESCRIPTION
very minor change: copy-pasteing the current url in the automatic install causes OS X to insert a automatic escape behind the pipe. Putting spaces in between prevents this and manual copying of the link.
