### PR TITLE
Fix printing PATH entry in error case

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ elif [ "$added_to_profile" = false ] && [ "$already_present" = false ]; then
     echo "== Error:"
     echo "   Found no profile to add apt-vim PATH to."
     echo "   Add the following line to your shell profile and source it to install manually:"
-    printf "   $exec_string\n"
+    printf "   $bin_string\n"
 else
     echo "== apt-vim installation succeeded! Run 'source ~/.bashrc || source ~/.bash_profile' or 'source ~/.zshrc'"
     echo "   to access the executable script."


### PR DESCRIPTION
Previously if we couldn't find a PATH entry to append to we would prent a
variable that had been undefined, which is just an empty string. Now print the
actual recommended path entry.